### PR TITLE
fix: don't turn a bare specifier into a file path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -103,7 +103,7 @@ export async function getPackageExportsManifest(options: PackageExportsManifestO
       exportsEntries.map(async ([key, value]) => {
         let obj: any
         if (importMode === 'package') {
-          obj = await import(pathToFileURL(join(pkg.name, key)).toString())
+          obj = await import(join(pkg.name, key))
         }
         else if (importMode === 'dist') {
           obj = await import(pathToFileURL(join(pkgRoot, value)).toString())

--- a/test/pkg.test.ts
+++ b/test/pkg.test.ts
@@ -90,7 +90,7 @@ it('vite', async () => {
     `)
 })
 
-it('rollup', async () => {
+it('rollup - dist', async () => {
   const manifest = await getPackageExportsManifest({
     importMode: 'dist',
     cwd: fileURLToPath(new URL('../node_modules/rollup', import.meta.url)),
@@ -120,6 +120,44 @@ it('rollup', async () => {
           },
         },
         "importMode": "dist",
+        "package": {
+          "name": "rollup",
+          "version": "4.54.0",
+        },
+      }
+    `)
+})
+
+it('rollup - package', async () => {
+  const manifest = await getPackageExportsManifest({
+    importMode: 'package',
+    cwd: fileURLToPath(new URL('../node_modules/rollup', import.meta.url)),
+  })
+
+  expect(manifest)
+    .toMatchInlineSnapshot(`
+      {
+        "exports": {
+          ".": {
+            "VERSION": "string",
+            "defineConfig": "function",
+            "rollup": "function",
+            "watch": "function",
+          },
+          "./getLogFilter": {
+            "getLogFilter": "function",
+          },
+          "./loadConfigFile": {
+            "default": "object",
+            "loadConfigFile": "function",
+            "module.exports": "object",
+          },
+          "./parseAst": {
+            "parseAst": "function",
+            "parseAstAsync": "function",
+          },
+        },
+        "importMode": "package",
         "package": {
           "name": "rollup",
           "version": "4.54.0",


### PR DESCRIPTION
See https://github.com/vitest-dev/vitest/pull/9354

`pkg.name` will never be an absolute path