### PR TITLE
feat: allow sequentially loading entry points

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,13 @@ export interface PackageExportsManifestOptions {
   cwd?: string
 
   /**
+   * How should entry points be imported.
+   *
+   * @default 'parallel'
+   */
+  sequence?: 'parallel' | 'sequential'
+
+  /**
    * The type of import source to use.
    *
    * - `package` - import from package name directly, for example `import('vitest/config')`
@@ -98,27 +105,38 @@ export async function getPackageExportsManifest(options: PackageExportsManifestO
 
   exportsEntries = options.resolveExportEntries?.(exportsEntries) ?? exportsEntries
 
-  const exports = Object.fromEntries(
-    await Promise.all(
-      exportsEntries.map(async ([key, value]) => {
-        let obj: any
-        if (importMode === 'package') {
-          obj = await import(join(pkg.name, key))
-        }
-        else if (importMode === 'dist') {
-          obj = await import(pathToFileURL(join(pkgRoot, value)).toString())
-        }
-        else if (importMode === 'src') {
-          obj = await import(pathToFileURL(join(pkgRoot, resolveSourcePath(value))).toString())
-        }
-        return [key, Object.fromEntries(
-          Object.entries(obj)
-            .map(([k, v]) => [k, resolveValueType(v)])
-            .sort((a, b) => a[0].localeCompare(b[0])),
-        )]
-      }),
-    ),
-  )
+  const importEntryPoint = async (key: string, value: string): Promise<Record<string, unknown>> => {
+    let obj: any
+    if (importMode === 'package') {
+      obj = await import(join(pkg.name, key))
+    }
+    else if (importMode === 'dist') {
+      obj = await import(pathToFileURL(join(pkgRoot, value)).toString())
+    }
+    else if (importMode === 'src') {
+      obj = await import(pathToFileURL(join(pkgRoot, resolveSourcePath(value))).toString())
+    }
+    return Object.fromEntries(
+      Object.entries(obj)
+        .map(([k, v]) => [k, resolveValueType(v)])
+        .sort((a, b) => a[0].localeCompare(b[0])),
+    )
+  }
+
+  let exports: Record<string, Record<string, unknown>> = {}
+
+  if (options.sequence === 'sequential') {
+    exports = Object.fromEntries(
+      await Promise.all(
+        exportsEntries.map(async ([key, value]) => [key, await importEntryPoint(key, value)]),
+      ),
+    )
+  }
+  else {
+    for (const [key, value] of exportsEntries) {
+      exports[key] = await importEntryPoint(key, value)
+    }
+  }
 
   return {
     package: {

--- a/test/pkg.test.ts
+++ b/test/pkg.test.ts
@@ -128,6 +128,45 @@ it('rollup - dist', async () => {
     `)
 })
 
+it('rollup - sequential', async () => {
+  const manifest = await getPackageExportsManifest({
+    importMode: 'dist',
+    sequence: 'sequential',
+    cwd: fileURLToPath(new URL('../node_modules/rollup', import.meta.url)),
+  })
+
+  expect(manifest)
+    .toMatchInlineSnapshot(`
+      {
+        "exports": {
+          ".": {
+            "VERSION": "string",
+            "defineConfig": "function",
+            "rollup": "function",
+            "watch": "function",
+          },
+          "./getLogFilter": {
+            "getLogFilter": "function",
+          },
+          "./loadConfigFile": {
+            "default": "object",
+            "loadConfigFile": "function",
+            "module.exports": "object",
+          },
+          "./parseAst": {
+            "parseAst": "function",
+            "parseAstAsync": "function",
+          },
+        },
+        "importMode": "dist",
+        "package": {
+          "name": "rollup",
+          "version": "4.55.1",
+        },
+      }
+    `)
+})
+
 it('rollup - package', async () => {
   const manifest = await getPackageExportsManifest({
     importMode: 'package',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

---

> Please be aware that vibe-coding contributions are **🚫 STRICTLY PROHIBITED**. 
> We are humans behind these open source projects, trying hard to maintain good quality and a healthy community. 
> Not only do vibe-coding contributions pollute the code, but they also drain A LOT of unnecessary energy and time from maintainers and toxify the community and collaboration.
>
> All vibe-coded, AI-generated PRs will be rejected and closed without further notice. In severe cases, your account might be banned organization-wide and reported to GitHub.
>
> **PLEASE SHOW SOME RESPECT** and do not do so.

---

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving and **WHY**, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

- [ ] <- Keep this line and put an `x` between the brackts.

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving, and "WHY" -->

### Linked Issues

fixes #<number>

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

This is a bit unorthodox, but when there is `require(esm)` in one of the dependencies, Node.js can break with this error:

```
Cannot require() ES Module index.js because it is not yet fully loaded. This may be caused by a race condition if the module is simultaneously dynamically import()-ed via Promise.all(). Try await-ing the import() sequentially in a loop instead. (from /source.js)
```

See PR in vitest: https://github.com/vitest-dev/vitest/actions/runs/21671470064/job/62480274147?pr=9586